### PR TITLE
Fixed bug of resolving urls with queries

### DIFF
--- a/src/modules/prisma/resolvers/frontend.resolver.ts
+++ b/src/modules/prisma/resolvers/frontend.resolver.ts
@@ -13,7 +13,7 @@ export class FrontendResolver {
 
   @Query('frontend')
   public async getLanguage(obj, args, context, info): Promise<any> {
-    const { url } = args.where;
+    let { url } = args.where;
 
     const emptyRes = null;
 
@@ -35,6 +35,10 @@ export class FrontendResolver {
     if (!origin) {
       return Promise.resolve(emptyRes);
     }
+
+    // Remove query from url, to correctly resolve page url
+    const queryRegex = /\?.*$/i;
+    url = url.replace(queryRegex, '');
 
     const originWithoutProtocolRegexRes = hostOriginRegex.exec(origin);
 


### PR DESCRIPTION
We have some issue with URLs like `https://www.pharmacentrum.cz/cs/na-dovolenou?fbclid=IwAR3rb4DE4K5nyyCdPibmWO279JoyY3zFyutqJy2FzFEP9_uAtrVXB4ucoKU` because resolver tries to find full URL with a query. Now the query is removed from URL before resolving...